### PR TITLE
Add tensorflow-macos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Arabic poetry analysis and generation.
 pip install .
 ```
 
+The `requirements.txt` file selects the correct TensorFlow package for your
+platform. On Linux and Windows it installs `tensorflow`, while on macOS it
+installs `tensorflow-macos`.
+
 ## Generation 
 
 ### Training 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ gradio
 tnkeeh
 pyarabic
 termcolor
-tensorflow==2.12.0
+tensorflow==2.12.0; platform_system!='Darwin'
+tensorflow-macos==2.12.0; platform_system=='Darwin'
 matplotlib==3.3.3
 gdown==4.6.0
 scikit-learn


### PR DESCRIPTION
## Summary
- allow tensorflow-macos on macOS via environment markers in requirements.txt
- mention tensorflow-macos in installation instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b03f044c883238233bfdae680b55b